### PR TITLE
Be more forgiving for some RSS elements

### DIFF
--- a/src/dtbell/feed.py
+++ b/src/dtbell/feed.py
@@ -101,7 +101,7 @@ class Feed:
             if any(key not in entry for key in ['title', 'link']):
                 attribute_errors += 1
                 continue
-            published = entry.get('published') or entry.get('pubDate') or entry.get('updated')
+            published = entry.get('published') or entry.get('updated')
             if not published:
                 attribute_errors += 1
                 continue

--- a/src/dtbell/feed.py
+++ b/src/dtbell/feed.py
@@ -98,16 +98,16 @@ class Feed:
         entries, new_entries = parsed_feed.get('entries', []), []
         current_time = datetime.utcnow().replace(tzinfo=pytz.UTC)
         for entry in entries:
-            if any(key not in entry for key in [
-                'title', 'author', 'link']
-            ):
+            if any(key not in entry for key in ['title', 'link']):
                 attribute_errors += 1
                 continue
-            published = entry.get('published') or entry.get('updated')
+            published = entry.get('published') or entry.get('pubDate') or entry.get('updated')
             if not published:
                 attribute_errors += 1
                 continue
+            entry.author = entry.get('author', "???")
             publish_date = parse(published)
+            if not publish_date.tzinfo: publish_date = publish_date.replace(tzinfo=pytz.UTC)
             entry_age = current_time - publish_date
             if (
                 entry_age < config.SEARCH_WINDOW


### PR DESCRIPTION
Hi!  After debugging why some older feeds weren't showing up (in particular https://research.ibm.com/haifa/ponderthis/rss/index.xml), I've put together a patch which makes the feed processing more forgiving in some aspects:

- Don't skip an entry if author is not set
- Fallback to `pubDate` if `published` is not set (`pubDate` also seems to be in the standard: https://www.rssboard.org/rss-draft-1#element-channel-pubdate?)
- Assume UTC if the publication date does not have a timezone

LMK what you think :slightly_smiling_face: 